### PR TITLE
Loading BIB from FLUKA: momentum discrepancy

### DIFF
--- a/utils/fluka_to_slcio.py
+++ b/utils/fluka_to_slcio.py
@@ -156,7 +156,7 @@ for iF, file_in in enumerate(args.files_in):
 		mom *= mom_tot
 
 		# Skipping if it's a neutron with too low kinetic energy
-		if args.ne_min is not None and abs(pdg) == 2112 and np.linalg.norm(e_kin) < args.ne_min:
+		if args.ne_min is not None and abs(pdg) == 2112 and e_kin < args.ne_min:
 			continue
 
 		# Calculating how many random copies of the particle to create according to the weight


### PR DESCRIPTION
From FLUKA, the kinetic energy is provided in the particle list in GeV. In fluka_to_slcio.py, the momentum of the particle should be set. No conversion is performed, and the kinetic energy is taken as the modulus of the momentum.
For photons, this should be harmless. However, for all massive particles, we can have some hiccups.

Noticeably, we can have electrons and positrons down to 100 KeV, where the effect is non negligible.